### PR TITLE
RS-14571: fix incorrect truncation of custom palette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChartBasics
 Type: Package
 Title: Pre-processing functions used for plotting
-Version: 2.3.4
+Version: 2.3.5
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Basic functions to be used by other charting packages (i.e., flipPlots, flipStandardCharts, flipPictographs). flipChartBasics is meant for internal functions. It should not be called directly by users.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,6 @@ Remotes:
     Displayr/flipTransformations,
     Displayr/flipFormat,
     Displayr/verbs
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 Depends: R (>= 2.10)

--- a/R/getvectorofcolors.R
+++ b/R/getvectorofcolors.R
@@ -74,16 +74,22 @@ GetVectorOfColors <- function (template,
 
     # Get vector of colors
     index <- if (type == "Pie subslice") 2 else 1
-    num.colors <- GetNumColors(input.data, chart.type, scatter.colors.column, multi.color.series)[[index]]
-    unordered.colors <- ChartColors(num.colors, given.colors = tmp.palette, 
-        custom.color = palette.custom.color,
-        custom.gradient.start = palette.custom.gradient.start, 
-        custom.gradient.end = palette.custom.gradient.end,
-        custom.palette = palette.custom.palette,
-        silent = chart.type %in% c("Pie", "Donut"),
-        silent.single.color = multi.color.series || 
-            chart.type %in% c("Bar Pictograph", "Time Series", "Pyramid"))
+    if (!is.null(color.values) && !is.null(palette.custom.palette))
+    {
+        unordered.colors <- TextAsVector(palette.custom.palette)
+    } else
+    {
+        num.colors <- GetNumColors(input.data, chart.type, scatter.colors.column, multi.color.series)[[index]]
+        unordered.colors <- ChartColors(num.colors, given.colors = tmp.palette, 
+            custom.color = palette.custom.color,
+            custom.gradient.start = palette.custom.gradient.start, 
+            custom.gradient.end = palette.custom.gradient.end,
+            custom.palette = palette.custom.palette,
+            silent = chart.type %in% c("Pie", "Donut"),
+            silent.single.color = multi.color.series || 
+                chart.type %in% c("Bar Pictograph", "Time Series", "Pyramid"))
 
+    }
     series.names <- GetBrandsFromData(input.data, filter, chart.type, 
         scatter.colors.column, multi.color.series, type)
     use.named.colors <- (palette %in% c("Default or template settings", "Brand colors")) && 

--- a/R/getvectorofcolors.R
+++ b/R/getvectorofcolors.R
@@ -28,7 +28,9 @@
 #' @param palette.custom.gradient.end A color specifying the end of the 
 #'  gradient when \code{palette} is set to \code{"Custom gradient"}.
 #' @param palette.custom.palette A vector or comma separated list of colors 
-#'  which will be recycled to the desired length.
+#'  which will be recycled to the desired length unless \code{color.values}
+#'  is provided in which case the whole vector will be used to construct
+#'  a color scale.
 #' @param color.values An optional numeric vector or matrix which can
 #'  be used with gradual palettes (either a custom gradient or one of
 #'  the sequential color palettes). The names of the vector or matrix

--- a/man/GetVectorOfColors.Rd
+++ b/man/GetVectorOfColors.Rd
@@ -67,7 +67,9 @@ the gradient when \code{palette} is set to \code{"Custom gradient"}.}
 gradient when \code{palette} is set to \code{"Custom gradient"}.}
 
 \item{palette.custom.palette}{A vector or comma separated list of colors 
-which will be recycled to the desired length.}
+which will be recycled to the desired length unless \code{color.values}
+is provided in which case the whole vector will be used to construct
+a color scale.}
 
 \item{color.values}{An optional numeric vector or matrix which can
 be used with gradual palettes (either a custom gradient or one of

--- a/tests/testthat/test-chartcolors.R
+++ b/tests/testthat/test-chartcolors.R
@@ -38,13 +38,39 @@ test_that("Alpha color values",
         "#FF000033", check.attributes = FALSE)
 })
 
-test_that("GetVectorOfColors always interpolates when values provided",
+test_that("GetVectorOfColors interpolates without truncation of custom palette when values provided",
 {
     xx <- matrix(rep(1:5, each=4), 4, 5, dimnames=list(letters[1:4], LETTERS[1:5]))
-    cc <- GetVectorOfColors(NULL, xx, chart.type = "Pyramid",
-            palette = "Custom palette", color.values = xx,
+    vv <- structure(c(0.427377197658643, 0.880951078841463, 0.186656802659854, 
+            0.127208865014836, 0.85857370775193, 0.480053373146802, 0.514949085423723, 
+            0.852327840169892, 0.519603841472417, 0.564817758277059, 0.0688090475741774, 
+            0.653883104445413, 0.148462921148166, 0.367752377409488, 0.722625317284837, 
+            0.198194843484089, 0.954959906404838, 0.391286951489747, 0.179487097775564, 
+            0.728933551348746), dim = 4:5)
+    colors.interp <- GetVectorOfColors(NULL, xx, chart.type = "Pyramid",
+            palette = "Custom palette", color.values = vv,
             palette.custom.palette = "#3e7dcc,#04b5ac,#f5c524,#c44e41,#7030A0")
-    expect_equal(cc[1,], c("#3E7DCC", "#04B5AC", "#F5C524", "#C44E41", "#7030A0"))
+    expect_equal(colors.interp, structure(c(
+        "#99BE57", "#8C3A80", "#1F9ABA", "#2E8BC3", "#943D76", 
+        "#D2C237", "#F4C324", "#963D73", "#F3C025", "#E9A82A", 
+        "#3E7DCC", "#D57836", "#2991C0", "#58BA7C", "#C6533F", 
+        "#1C9DB9", "#7030A0", "#71BC6E", "#2198BC", "#C45040"), dim = 4:5))
+})
+  
+test_that("GetVectorOfColors truncates/recycles custom palette if no values provided", 
+{
+    xx <- matrix(rep(1:5, each=4), 4, 5, dimnames=list(letters[1:4], LETTERS[1:5]))
+    colors.for.row <- GetVectorOfColors(NULL, xx, chart.type = "Bar",
+            palette = "Custom palette", multi.color.series = TRUE,
+            palette.custom.palette = "#3e7dcc,#04b5ac,#f5c524,#c44e41,#7030A0")
+    expect_equal(unname(colors.for.row), c("#3E7DCC", "#04B5AC", "#F5C524", "#C44E41"))
+    colors.for.column <- expect_warning(GetVectorOfColors(NULL, xx, chart.type = "Bar",
+            palette = "Custom palette", multi.color.series = FALSE,
+            palette.custom.palette = "#3e7dcc,#04b5ac,#f5c524"))
+    expect_equal(unname(colors.for.column), c("#3E7DCC", "#04B5AC", "#F5C524", "#3E7DCC", "#04B5AC"))
+    expect_equal(colors.for.row, GetVectorOfColors(NULL, xx, chart.type = "Pyramid",
+            palette = "Custom palette",
+            palette.custom.palette = "#3e7dcc,#04b5ac,#f5c524,#c44e41,#7030A0"))
 })
 
 test_that("ChartColors handles arguments", {

--- a/tests/testthat/test-chartcolors.R
+++ b/tests/testthat/test-chartcolors.R
@@ -38,6 +38,15 @@ test_that("Alpha color values",
         "#FF000033", check.attributes = FALSE)
 })
 
+test_that("GetVectorOfColors always interpolates when values provided",
+{
+    xx <- matrix(rep(1:5, each=4), 4, 5, dimnames=list(letters[1:4], LETTERS[1:5]))
+    cc <- GetVectorOfColors(NULL, xx, chart.type = "Pyramid",
+            palette = "Custom palette", color.values = xx,
+            palette.custom.palette = "#3e7dcc,#04b5ac,#f5c524,#c44e41,#7030A0")
+    expect_equal(cc[1,], c("#3E7DCC", "#04B5AC", "#F5C524", "#C44E41", "#7030A0"))
+})
+
 test_that("ChartColors handles arguments", {
     res2 <- ChartColors(2)
     res2b <- ChartColors(2, "Default colors")


### PR DESCRIPTION
Fix truncation of color palette - this only applies to the case when the a color.values vector is given and we expect the color palette to be linearly interpolated instead of recycled (there's no problem when a sequential color palette is chosen (e.g Reds, Greens), because the interpolation is handled by the palette.)
