### PR TITLE
RS-22278: Fix Values color option error when values are all identical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipChartBasics
 Type: Package
 Title: Pre-processing functions used for plotting
-Version: 2.3.5
+Version: 2.3.6
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Basic functions to be used by other charting packages (i.e., flipPlots, flipStandardCharts, flipPictographs). flipChartBasics is meant for internal functions. It should not be called directly by users.

--- a/R/getvectorofcolors.R
+++ b/R/getvectorofcolors.R
@@ -149,8 +149,15 @@ GetVectorOfColors <- function (template,
             StopForUserError("Color values must be numeric")
         if (any(is.na(vals)))
             StopForUserError("Color values cannot contain missing values")
-        vals <- (vals - min(as.numeric(vals), na.rm = TRUE))
-        vals <- vals/max(as.numeric(vals), na.rm = TRUE)
+        val.min <- min(as.numeric(vals), na.rm = TRUE)
+        val.max <- max(as.numeric(vals), na.rm = TRUE)
+        # When all values are identical there is no range to map onto the
+        # color scale. Dividing by a zero range would give NaN and error out
+        # in rgb(), so map every value to the midpoint of the scale instead.
+        if (val.max == val.min)
+            vals[] <- 0.5
+        else
+            vals <- (vals - val.min) / (val.max - val.min)
 
         color.fun <- colorRamp(unordered.colors)
         color.scale <- rgb(color.fun(as.numeric(vals)), maxColorValue = 255)

--- a/tests/testthat/test-chartcolors.R
+++ b/tests/testthat/test-chartcolors.R
@@ -57,7 +57,19 @@ test_that("GetVectorOfColors interpolates without truncation of custom palette w
         "#1C9DB9", "#7030A0", "#71BC6E", "#2198BC", "#C45040"), dim = 4:5))
 })
   
-test_that("GetVectorOfColors truncates/recycles custom palette if no values provided", 
+test_that("GetVectorOfColors handles color values that are all identical",
+{
+    xx <- matrix(rep(1:5, each=4), 4, 5, dimnames=list(letters[1:4], LETTERS[1:5]))
+    vv <- matrix(2, 4, 5, dimnames=list(letters[1:4], LETTERS[1:5]))
+    colors <- expect_error(GetVectorOfColors(NULL, xx, chart.type = "Column",
+            palette = "Custom palette", color.values = vv, small.multiples = TRUE,
+            palette.custom.palette = "#3e7dcc,#04b5ac,#f5c524"), NA)
+    # No range in the values, so every value maps to the midpoint of the scale
+    expect_equal(unname(as.vector(colors)), rep("#04B5AC", 20))
+    expect_equal(dim(colors), c(4L, 5L))
+})
+
+test_that("GetVectorOfColors truncates/recycles custom palette if no values provided",
 {
     xx <- matrix(rep(1:5, each=4), 4, 5, dimnames=list(letters[1:4], LETTERS[1:5]))
     colors.for.row <- GetVectorOfColors(NULL, xx, chart.type = "Bar",


### PR DESCRIPTION
GetVectorOfColors normalized color.values via (vals - min) / max(vals - min). When every value is the same the range is zero, so this computes 0/0 = NaN, which colorRamp propagates and rgb() rejects with "color intensity NA, not in 0:255".

Guard the zero-range case and map all values to the midpoint of the color scale (0.5) instead. For the reported 3-colour custom palette this resolves to the middle colour, matching the expected result.